### PR TITLE
1.3.1

### DIFF
--- a/addons/xdut-task/plugin.cfg
+++ b/addons/xdut-task/plugin.cfg
@@ -3,5 +3,5 @@
 name="XDUT Task"
 description="将来決まる値を共通のインターフェイスを通して扱うためのクラスセットを含む、非同期的スクリプティングを補助するためのアドオンです。"
 author="Ydi (@ydipeepo.bsky.social)"
-version="1.3.0"
+version="1.3.1"
 script="plugin.gd"


### PR DESCRIPTION
* #21 Godot Engine 4.4 に対応

アドオン本体の修正を含まないため `./addons/xdut-task` 以下のみプロジェクトに追加している場合の対応は不要です。